### PR TITLE
Feature: Automatically unmonitor watched content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 config.toml
+.zed/

--- a/example.config.toml
+++ b/example.config.toml
@@ -9,6 +9,7 @@ base_url = "http://localhost:7878"
 api_key = "api-key-foo"
 tags_to_keep = ["keep"]
 retention_period = "2d"
+unmonitor = false
 
 [sonarr]
 base_url = "http://localhost:7878"

--- a/example.config.toml
+++ b/example.config.toml
@@ -16,6 +16,7 @@ base_url = "http://localhost:7878"
 api_key = "api-key-foo"
 tags_to_keep = ["keep"]
 retention_period = "1w"
+unmonitor = false
 
 [download_clients.qbittorrent]
 base_url = "http://localhost:8080"

--- a/readme.md
+++ b/readme.md
@@ -35,14 +35,14 @@ base_url = "http://localhost:7878"
 api_key = "sadfa2345234asdfasd2345234"
 tags_to_keep = ["keep"]
 retention_period = "2d"
-unmonitor = false  # Set to true to unmonitor watched movies
+unmonitor = false
 
 [sonarr]
 base_url = "http://localhost:8989"
 api_key = "sadfa2345234asdfasd2345234"
 tags_to_keep = ["keep", "no_remove"]
 retention_period = "1w"
-unmonitor = false  # Set to true to unmonitor watched episodes
+unmonitor = false
 
 # You can configure multiple download clients running in your system.
 # Currently only 'qBittorrent' and 'Deluge' are supported.

--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,7 @@ thereby reducing the size of your collection on the disk.
 - Cleans up movies and series based on your configuration;
 - Supports custom tags to keep specific files;
 - Provides logging and error handling;
+- Unmonitor watched content: Automatically unmonitor watched movies in Radarr and watched series in Sonar;
 
 ## Configuration
 
@@ -34,16 +35,18 @@ base_url = "http://localhost:7878"
 api_key = "sadfa2345234asdfasd2345234"
 tags_to_keep = ["keep"]
 retention_period = "2d"
+unmonitor = false  # Set to true to unmonitor watched movies
 
 [sonarr]
 base_url = "http://localhost:8989"
 api_key = "sadfa2345234asdfasd2345234"
 tags_to_keep = ["keep", "no_remove"]
 retention_period = "1w"
+unmonitor = false  # Set to true to unmonitor watched episodes
 
 # You can configure multiple download clients running in your system.
 # Currently only 'qBittorrent' and 'Deluge' are supported.
-# Which client to delete a specific torrent from will be decided 
+# Which client to delete a specific torrent from will be decided
 # automatically based on the API response from either Sonarr or Radarr.
 # See "History" API reference for more details
 # - https://sonarr.tv/docs/api/#/History/get_api_v3_history
@@ -113,7 +116,7 @@ services:
       INTERVAL: 45m
     volumes:
       - /path/to/sanitarr-config.toml:/app/config.toml
-    command: 
+    command:
       - "--config"
       - "/app/config.toml"
       - "--force-delete"

--- a/src/cleaners/movies.rs
+++ b/src/cleaners/movies.rs
@@ -49,12 +49,10 @@ impl MoviesCleaner {
     pub async fn cleanup(&self, user_name: &str, force_delete: bool) -> anyhow::Result<()> {
         let user = self.jellyfin.user(user_name).await?;
 
-        // Handle unmonitor functionality separately
         if self.unmonitor {
             self.handle_unmonitor(&user.id, force_delete).await?;
         }
 
-        // Original deletion logic with retention period and tags
         let items = self.watched_items(&user.id).await?;
         if items.is_empty() {
             log::info!("no movies found for deletion in Jellyfin!");
@@ -185,7 +183,7 @@ impl MoviesCleaner {
             .await?
             .into_iter()
             .flat_map(Vec::into_iter)
-            .filter(|movie| movie.monitored.unwrap_or(true)) // Only include monitored movies (default to true if field is missing)
+            .filter(|movie| movie.monitored.unwrap_or(true))
             .collect();
         Ok(movies)
     }

--- a/src/cleaners/series.rs
+++ b/src/cleaners/series.rs
@@ -1,7 +1,9 @@
 use crate::{
     cleaners::utils,
     config::SonarrConfig,
-    http::{Item, ItemsFilter, JellyfinClient, SeriesInfo, SonarrClient, TorrentClientKind},
+    http::{
+        Item, ItemsFilter, JellyfinClient, SeriesInfo, SonarrClient, TorrentClientKind, UserId,
+    },
     services::DownloadService,
 };
 use log::{debug, info, warn};
@@ -18,6 +20,7 @@ pub struct SeriesCleaner {
     download_client: DownloadService,
     tags_to_keep: Vec<String>,
     retention_period: Option<Duration>,
+    unmonitor: bool,
 }
 
 impl SeriesCleaner {
@@ -31,6 +34,7 @@ impl SeriesCleaner {
             api_key,
             tags_to_keep,
             retention_period,
+            unmonitor,
         } = sonarr_config;
 
         let sonarr_client = SonarrClient::new(&base_url, &api_key)?;
@@ -40,11 +44,20 @@ impl SeriesCleaner {
             download_client,
             tags_to_keep,
             retention_period,
+            unmonitor,
         })
     }
 
     /// cleanup fully watched series from Sonarr and Download client
     pub async fn cleanup(&self, user_name: &str, force_delete: bool) -> anyhow::Result<()> {
+        let user = self.jellyfin.user(user_name).await?;
+
+        // Handle unmonitor functionality separately
+        if self.unmonitor {
+            self.handle_unmonitor(&user.id, force_delete).await?;
+        }
+
+        // Original deletion logic with retention period and tags
         let items = self.watched_items(user_name).await?;
 
         if items.is_empty() {
@@ -203,6 +216,143 @@ impl SeriesCleaner {
             .flat_map(|i| i.into_iter())
             .collect::<Vec<SeriesInfo>>();
         Ok(series)
+    }
+
+    /// Handle unmonitoring watched episodes in series
+    async fn handle_unmonitor(&self, user_id: &UserId, force_delete: bool) -> anyhow::Result<()> {
+        let watched_series = self.all_watched_series(user_id).await?;
+        if watched_series.is_empty() {
+            return Ok(());
+        }
+
+        let episodes_to_unmonitor = self
+            .episodes_for_unmonitoring(&watched_series, user_id)
+            .await?;
+        if episodes_to_unmonitor.is_empty() {
+            return Ok(());
+        }
+
+        if force_delete {
+            debug!(
+                "trying to unmonitor {} episodes in Sonarr",
+                episodes_to_unmonitor.len()
+            );
+            self.sonarr_client
+                .unmonitor_episodes(&episodes_to_unmonitor)
+                .await?;
+            info!(
+                "successfully unmonitored {} episodes in Sonarr",
+                episodes_to_unmonitor.len()
+            );
+        } else {
+            info!(
+                "dry run mode - {} episodes would be unmonitored",
+                episodes_to_unmonitor.len()
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Get all series with at least one watched episode (for unmonitor)
+    async fn all_watched_series(&self, user_id: &UserId) -> anyhow::Result<Vec<Item>> {
+        // Get all series (not just fully watched ones)
+        let all_series = self
+            .jellyfin
+            .items(
+                ItemsFilter::new()
+                    .user_id(user_id.as_ref())
+                    .recursive()
+                    .include_item_types(&["Series"])
+                    .fields(&["ProviderIds"]),
+            )
+            .await?;
+
+        let mut series_with_watched_episodes = Vec::new();
+
+        // Check each series for watched episodes
+        for series in all_series {
+            let watched_episodes_filter = ItemsFilter::new()
+                .user_id(user_id.as_ref())
+                .recursive()
+                .parent_id(&series.id)
+                .include_item_types(&["Episode"])
+                .played();
+
+            let watched_episodes = self.jellyfin.items(watched_episodes_filter).await?;
+
+            // If the series has at least one watched episode, include it
+            if !watched_episodes.is_empty() {
+                series_with_watched_episodes.push(series);
+            }
+        }
+
+        Ok(series_with_watched_episodes)
+    }
+
+    /// Get episodes that should be unmonitored (watched episodes in watched series)
+    async fn episodes_for_unmonitoring(
+        &self,
+        watched_series: &[Item],
+        user_id: &UserId,
+    ) -> anyhow::Result<HashSet<u64>> {
+        let mut episodes_to_unmonitor = HashSet::new();
+
+        for series_item in watched_series {
+            // Get only watched episodes using the played filter directly from Jellyfin
+            let watched_episodes_filter = ItemsFilter::new()
+                .user_id(user_id.as_ref())
+                .recursive()
+                .parent_id(&series_item.id)
+                .include_item_types(&["Episode"])
+                .played();
+
+            let watched_episodes = self.jellyfin.items(watched_episodes_filter).await?;
+            // debug!(
+            //     "found watched episodes to unmonitor: {}, in series {}, tvdb_id: {}",
+            //     watched_episodes.len(),
+            //     series_item.name,
+            //     series_item.tvdb_id().unwrap_or("0")
+            // );
+
+            if watched_episodes.is_empty() {
+                continue;
+            }
+
+            // Get series from Sonarr by TVDB ID
+            if let Some(tvdb_id) = series_item.tvdb_id() {
+                let sonarr_series = self.sonarr_client.series_by_tvdb_id(tvdb_id).await?;
+
+                for series in sonarr_series {
+                    // Get all episodes for this series from Sonarr
+                    let sonarr_episodes =
+                        self.sonarr_client.episodes_by_series_id(series.id).await?;
+
+                    // Match watched Jellyfin episodes with Sonarr episodes and collect IDs
+                    for watched_episode in &watched_episodes {
+                        if let (Some(season_num), Some(episode_num)) = (
+                            watched_episode.parent_index_number,
+                            watched_episode.index_number,
+                        ) {
+                            // Find matching episode in Sonarr that is currently monitored
+                            if let Some(sonarr_episode) = sonarr_episodes.iter().find(|ep| {
+                                ep.season_number == season_num as u32
+                                    && ep.episode_number == episode_num as u32
+                                    && ep.monitored.unwrap_or(true) // Only include monitored episodes
+                            }) {
+                                episodes_to_unmonitor.insert(sonarr_episode.id);
+                                debug!(
+                                    "found watched episode to unmonitor: {} S{}E{} (ID: {})",
+                                    series_item.name, season_num, episode_num, sonarr_episode.id
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(episodes_to_unmonitor)
     }
 
     /// delete series with given ids

--- a/src/cleaners/series.rs
+++ b/src/cleaners/series.rs
@@ -308,12 +308,6 @@ impl SeriesCleaner {
                 .played();
 
             let watched_episodes = self.jellyfin.items(watched_episodes_filter).await?;
-            // debug!(
-            //     "found watched episodes to unmonitor: {}, in series {}, tvdb_id: {}",
-            //     watched_episodes.len(),
-            //     series_item.name,
-            //     series_item.tvdb_id().unwrap_or("0")
-            // );
 
             if watched_episodes.is_empty() {
                 continue;

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,6 +41,8 @@ pub struct SonarrConfig {
     pub retention_period: Option<Duration>,
     #[serde(default)]
     pub tags_to_keep: Vec<String>,
+    #[serde(default)]
+    pub unmonitor: bool,
 }
 
 #[derive(Deserialize)]
@@ -103,6 +105,7 @@ mod test {
         assert_eq!(&cfg.sonarr.tags_to_keep, &["keep".to_owned()]);
         let dur = 60 * 60 * 24 * 7;
         assert_eq!(cfg.sonarr.retention_period, Some(Duration::from_secs(dur)));
+        assert_eq!(cfg.sonarr.unmonitor, false);
 
         let deluge_cfg = &cfg
             .download_clients

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,8 @@ pub struct RadarrConfig {
     pub retention_period: Option<Duration>,
     #[serde(default)]
     pub tags_to_keep: Vec<String>,
+    #[serde(default)]
+    pub unmonitor: bool,
 }
 
 #[derive(Deserialize)]
@@ -94,6 +96,7 @@ mod test {
         assert_eq!(&cfg.radarr.tags_to_keep, &["keep".to_owned()]);
         let dur = 60 * 60 * 24 * 2;
         assert_eq!(cfg.radarr.retention_period, Some(Duration::from_secs(dur)));
+        assert_eq!(cfg.radarr.unmonitor, false);
 
         assert_eq!(cfg.sonarr.base_url, "http://localhost:7878");
         assert_eq!(cfg.sonarr.api_key, "api-key-foo");

--- a/src/http/jellyfin_client.rs
+++ b/src/http/jellyfin_client.rs
@@ -96,6 +96,8 @@ pub struct Item {
     pub id: String,
     pub provider_ids: Option<ProviderIds>,
     pub user_data: Option<ItemUserData>,
+    pub parent_index_number: Option<i32>,
+    pub index_number: Option<i32>,
 }
 
 impl Item {


### PR DESCRIPTION
Hey man, you made a great project for people who don't like to hoard stuff.

I made a new feature, firstly for me, but maybe you're interested too - **Unmonitor**.

It will unmonitor every movie or episode that was already marked as watched after the last check. This way, you don't need to download and store a new version of media that was already watched and would be deleted anyway.

Let me know what you think.