### PR TITLE
feat: implement episode-level deletion for TV shows

### DIFF
--- a/src/cleaners/episodes.rs
+++ b/src/cleaners/episodes.rs
@@ -1,0 +1,412 @@
+//! Episode-level deletion for TV shows from Sonarr.
+//!
+//! EpisodesCleaner monitors Jellyfin for watched episodes and deletes them from Sonarr
+//! while preserving the series and unwatched episodes. This provides fine-grained control
+//! over disk space usage compared to series-level deletion.
+//!
+//! # Deletion Workflow
+//!
+//! 1. Query Jellyfin for watched episodes matching retention period criteria
+//! 2. Group episodes by TVDB ID (series identifier)
+//! 3. For each series:
+//!    - Check if series has forbidden tags (if found, skip entire series)
+//!    - Fetch all episodes from Sonarr for the series
+//!    - Match Jellyfin watched episodes to Sonarr episodes by season/episode number
+//! 4. For each episode to delete:
+//!    - **Unmonitor episode in Sonarr FIRST** (prevents re-download attempts)
+//!    - Delete episode file from disk SECOND (safe now that it's unmonitored)
+//!
+//! # Critical Design Notes
+//!
+//! ## Episode Matching
+//! Episodes are matched by season/episode number instead of episode ID because:
+//! - Jellyfin episode IDs don't correspond to Sonarr episode IDs
+//! - Season/episode numbers are reliable identifiers across systems
+//!
+//! Limitations:
+//! - Special episodes (Season 0) may number differently between systems
+//! - Absolute numbering (anime) may not map correctly to season/episode
+//!
+//! ## Unmonitor-First Design
+//! Episodes MUST be unmonitored before file deletion to prevent race conditions:
+//! - If file is deleted first: Sonarr sees episode as "missing" and re-downloads it
+//! - If unmonitored first: Sonarr knows episode was intentionally removed
+//!
+//! This prevents wasted bandwidth and achieves the cleanup goal.
+//!
+//! # Field Requirements
+//!
+//! Jellyfin must provide these fields for episodes:
+//! - `ProviderIds.Tvdb` - Series TVDB ID for Sonarr lookup
+//! - `ParentIndexNumber` - Season number
+//! - `IndexNumber` - Episode number
+//! - `UserData.LastPlayedDate` - For retention period filtering
+//!
+//! If any required field is missing, the episode is skipped with a warning log.
+
+use crate::{
+    cleaners::utils,
+    config::SonarrConfig,
+    http::{EpisodeInfo, Item, ItemsFilter, JellyfinClient, SeriesInfo, SonarrClient},
+    services::DownloadService,
+};
+use log::{debug, info, warn};
+use std::{
+    collections::HashMap,
+    time::Duration,
+};
+
+/// EpisodesCleaner is responsible for cleaning up watched episodes from Sonarr.
+/// Unlike SeriesCleaner which deletes entire series, EpisodesCleaner deletes
+/// individual episodes while preserving unwatched episodes in the same series.
+pub struct EpisodesCleaner {
+    sonarr_client: SonarrClient,
+    jellyfin: JellyfinClient,
+    #[allow(dead_code)]
+    download_client: DownloadService,
+    tags_to_keep: Vec<String>,
+    retention_period: Option<Duration>,
+}
+
+/// Track episodes to be deleted
+struct EpisodeFileDeletion {
+    series_title: String,
+    season: u32,
+    episode: u32,
+    episode_id: u64,       // CRITICAL: Needed for unmonitoring
+    episode_file_id: u64,  // Needed for file deletion
+}
+
+impl EpisodesCleaner {
+    pub fn new(
+        sonarr_config: SonarrConfig,
+        jellyfin: JellyfinClient,
+        download_client: DownloadService,
+    ) -> anyhow::Result<Self> {
+        let SonarrConfig {
+            base_url,
+            api_key,
+            tags_to_keep,
+            retention_period,
+        } = sonarr_config;
+
+        let sonarr_client = SonarrClient::new(&base_url, &api_key)?;
+        Ok(Self {
+            sonarr_client,
+            jellyfin,
+            download_client,
+            tags_to_keep,
+            retention_period,
+        })
+    }
+
+    /// cleanup fully watched episodes from Sonarr
+    pub async fn cleanup(&self, user_name: &str, force_delete: bool) -> anyhow::Result<()> {
+        let episodes = self.watched_episodes(user_name).await?;
+
+        if episodes.is_empty() {
+            info!("no fully watched episodes found!");
+            return Ok(());
+        }
+
+        let files_to_delete = self.episode_files_for_deletion(&episodes).await?;
+
+        if files_to_delete.is_empty() {
+            info!("no episode files found for deletion!");
+            return Ok(());
+        }
+
+        if force_delete {
+            debug!("deleting {} episode files", files_to_delete.len());
+            let mut success_count = 0;
+            let mut failure_count = 0;
+
+            for file in &files_to_delete {
+                match self.delete_single_episode(file).await {
+                    Ok(_) => {
+                        success_count += 1;
+                        info!(
+                            "deleted and unmonitored: {} S{:02}E{:02}",
+                            file.series_title, file.season, file.episode
+                        );
+                    }
+                    Err(e) => {
+                        failure_count += 1;
+                        log::error!(
+                            "failed to delete {} S{:02}E{:02} (episode_id: {}, file_id: {}): {}",
+                            file.series_title,
+                            file.season,
+                            file.episode,
+                            file.episode_id,
+                            file.episode_file_id,
+                            e
+                        );
+                    }
+                }
+            }
+
+            info!(
+                "deletion complete: {} succeeded, {} failed",
+                success_count, failure_count
+            );
+
+            if failure_count > 0 {
+                return Err(anyhow::anyhow!(
+                    "failed to delete {} out of {} episodes",
+                    failure_count,
+                    files_to_delete.len()
+                ));
+            }
+        } else {
+            info!("no items will be deleted as no `--force-delete` flag is provided. Listing them instead:");
+            for file in &files_to_delete {
+                info!("  - {} S{:02}E{:02}", file.series_title, file.season, file.episode);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Delete a single episode: unmonitor FIRST, then delete file
+    ///
+    /// Order is critical: unmonitoring must happen before file deletion to prevent
+    /// Sonarr from seeing the episode as "missing" and attempting to re-download it.
+    async fn delete_single_episode(&self, file: &EpisodeFileDeletion) -> anyhow::Result<()> {
+        // Step 1: CRITICAL - Unmonitor the episode FIRST to prevent re-download attempts
+        // This tells Sonarr "this episode was intentionally removed, don't fetch it again"
+        self.sonarr_client
+            .unmonitor_episode(file.episode_id)
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "failed to unmonitor episode: {}",
+                    e
+                )
+            })?;
+
+        // Step 2: Delete the episode file from disk (safe now that it's unmonitored)
+        self.sonarr_client
+            .delete_episode_file(file.episode_file_id)
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "failed to delete episode file after unmonitoring: {}",
+                    e
+                )
+            })?;
+
+        Ok(())
+    }
+
+    /// Query Jellyfin for watched episodes with retention period filtering
+    async fn watched_episodes(&self, user_name: &str) -> anyhow::Result<Vec<Item>> {
+        let user_id = self.jellyfin.user(user_name).await?.id;
+
+        // Query Jellyfin for watched Episode items (not Series)
+        // Must explicitly request all needed fields: ProviderIds for series matching,
+        // and season/episode numbers for episode matching
+        let episodes = self
+            .jellyfin
+            .items(
+                ItemsFilter::watched()
+                    .user_id(user_id.as_ref())
+                    .include_item_types(&["Episode"])
+                    .fields(&["ProviderIds", "SeriesId", "SeriesName"]),
+            )
+            .await?;
+
+        // Filter by retention period
+        let Some(retention_period) = self.retention_period else {
+            if !episodes.is_empty() {
+                warn!("no retention period set, will delete episodes immediately");
+            }
+            return Ok(episodes);
+        };
+
+        let retention_date = chrono::Utc::now() - retention_period;
+        let safe_to_delete = episodes
+            .into_iter()
+            .filter(|episode| {
+                let should_delete = episode
+                    .user_data
+                    .as_ref()
+                    .and_then(|ud| ud.last_played_date)
+                    .map(|last_played| retention_date > last_played)
+                    .unwrap_or(false);
+
+                if !should_delete {
+                    let last_played_str = episode
+                        .user_data
+                        .as_ref()
+                        .and_then(|ud| ud.last_played_date)
+                        .map(|dt| dt.to_rfc3339())
+                        .unwrap_or_else(|| "unknown".to_string());
+                    debug!(
+                        "Episode {} not eligible for deletion (last played: {})",
+                        episode.name, last_played_str
+                    );
+                }
+                should_delete
+            })
+            .collect();
+
+        Ok(safe_to_delete)
+    }
+
+    /// Get the list of forbidden tag IDs from Sonarr
+    async fn forbidden_tags(&self) -> anyhow::Result<Vec<u64>> {
+        debug!("forbidden tags configured: {:?}", self.tags_to_keep);
+
+        let tags = self.sonarr_client.tags().await?;
+        let forbidden_tags = tags
+            .iter()
+            .filter(|t| self.tags_to_keep.contains(&t.label))
+            .map(|t| t.id)
+            .collect();
+
+        debug!("forbidden tag ids: {forbidden_tags:?}");
+
+        Ok(forbidden_tags)
+    }
+
+    /// Check if series has any forbidden tags
+    fn has_forbidden_tags(series: &SeriesInfo, forbidden_tags: &[u64]) -> bool {
+        series
+            .tags
+            .as_ref()
+            .is_some_and(|tags| tags.iter().any(|tag| forbidden_tags.contains(tag)))
+    }
+
+    /// Map Jellyfin episodes to Sonarr episode files for deletion
+    async fn episode_files_for_deletion(
+        &self,
+        jellyfin_episodes: &[Item],
+    ) -> anyhow::Result<Vec<EpisodeFileDeletion>> {
+        // Group episodes by TVDB ID (series identifier)
+        let mut by_tvdb: HashMap<String, Vec<&Item>> = HashMap::new();
+        for ep in jellyfin_episodes {
+            if let Some(tvdb_id) = ep.tvdb_id() {
+                by_tvdb
+                    .entry(tvdb_id.to_string())
+                    .or_insert_with(Vec::new)
+                    .push(ep);
+            } else {
+                warn!(
+                    "Episode '{}' has no TVDB ID, cannot match to Sonarr series, skipping",
+                    ep.name
+                );
+            }
+        }
+
+        let mut files_to_delete = Vec::new();
+        let forbidden_tags = self.forbidden_tags().await?;
+
+        for (tvdb_id, jellyfin_episodes) in by_tvdb {
+            // Get Sonarr series by TVDB ID
+            let series_list = self.sonarr_client.series_by_tvdb_id(&tvdb_id).await?;
+
+            for series in series_list {
+                // Check if series has forbidden tags
+                if Self::has_forbidden_tags(&series, &forbidden_tags) {
+                    debug!(
+                        "Series {} has forbidden tags, skipping all episodes",
+                        series.title
+                    );
+                    continue;
+                }
+
+                // Get ALL episodes for this series from Sonarr
+                let sonarr_episodes = self.sonarr_client.episodes_by_series(series.id).await?;
+
+                // For each Jellyfin watched episode, find matching Sonarr episode
+                for jellyfin_ep in &jellyfin_episodes {
+                    let season = jellyfin_ep.season_number();
+                    let episode = jellyfin_ep.episode_number();
+
+                    // Validate that we have season and episode numbers
+                    let (season_num, ep_num) = match (season, episode) {
+                        (Some(s), Some(e)) => (s, e),
+                        (None, Some(e)) => {
+                            warn!(
+                                "Episode '{}' from series {} missing season number, skipping",
+                                jellyfin_ep.name, series.title
+                            );
+                            continue;
+                        }
+                        (Some(s), None) => {
+                            warn!(
+                                "Episode '{}' from series {} missing episode number, skipping",
+                                jellyfin_ep.name, series.title
+                            );
+                            continue;
+                        }
+                        (None, None) => {
+                            warn!(
+                                "Episode '{}' from series {} missing both season and episode numbers, skipping",
+                                jellyfin_ep.name, series.title
+                            );
+                            continue;
+                        }
+                    };
+
+                    // Match by season and episode number (direct from Jellyfin!)
+                    match sonarr_episodes
+                        .iter()
+                        .find(|se| se.season_number == season_num && se.episode_number == ep_num)
+                    {
+                        Some(sonarr_ep) => {
+                            // Validate that episode has a file on disk before attempting deletion
+                            match sonarr_ep.episode_file_id {
+                                Some(file_id) => {
+                                    files_to_delete.push(EpisodeFileDeletion {
+                                        series_title: series.title.clone(),
+                                        season: season_num,
+                                        episode: ep_num,
+                                        episode_id: sonarr_ep.id,
+                                        episode_file_id: file_id,
+                                    });
+                                }
+                                None => {
+                                    debug!(
+                                        "Episode {} S{:02}E{:02} has no file on disk in Sonarr, skipping",
+                                        series.title, season_num, ep_num
+                                    );
+                                }
+                            }
+                        }
+                        None => {
+                            debug!(
+                                "Episode {} S{:02}E{:02} not found in Sonarr, skipping",
+                                series.title, season_num, ep_num
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(files_to_delete)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_episode_file_deletion_formatting() {
+        let deletion = EpisodeFileDeletion {
+            series_title: "Breaking Bad".to_string(),
+            season: 1,
+            episode: 5,
+            episode_id: 123,
+            episode_file_id: 456,
+        };
+
+        let formatted = format!(
+            "{} S{:02}E{:02}",
+            deletion.series_title, deletion.season, deletion.episode
+        );
+        assert_eq!(formatted, "Breaking Bad S01E05");
+    }
+}

--- a/src/cleaners/mod.rs
+++ b/src/cleaners/mod.rs
@@ -1,6 +1,8 @@
 mod movies;
 mod series;
+mod episodes;
 mod utils;
 
 pub use movies::MoviesCleaner;
 pub use series::SeriesCleaner;
+pub use episodes::EpisodesCleaner;

--- a/src/http/jellyfin_client.rs
+++ b/src/http/jellyfin_client.rs
@@ -96,6 +96,11 @@ pub struct Item {
     pub id: String,
     pub provider_ids: Option<ProviderIds>,
     pub user_data: Option<ItemUserData>,
+    // Episode-specific fields (only present for Episode items)
+    pub parent_index_number: Option<u32>,  // Season number
+    pub index_number: Option<u32>,         // Episode number
+    pub series_id: Option<String>,         // Parent series ID (for episodes)
+    pub series_name: Option<String>,       // Parent series name (for display)
 }
 
 impl Item {
@@ -105,6 +110,19 @@ impl Item {
 
     pub fn tvdb_id(&self) -> Option<&str> {
         self.provider_ids.as_ref()?.tvdb.as_deref()
+    }
+
+    // Helper methods for episodes
+    pub fn season_number(&self) -> Option<u32> {
+        self.parent_index_number
+    }
+
+    pub fn episode_number(&self) -> Option<u32> {
+        self.index_number
+    }
+
+    pub fn series_jellyfin_id(&self) -> Option<&str> {
+        self.series_id.as_deref()
     }
 }
 

--- a/src/http/jellyfin_client.rs
+++ b/src/http/jellyfin_client.rs
@@ -71,6 +71,28 @@ impl JellyfinClient {
             .find(|user| user.name == user_name)
             .ok_or_else(|| anyhow::anyhow!("User {user_name} not found"))
     }
+
+    /// Get series by Jellyfin series ID
+    /// https://api.jellyfin.org/#tag/Items/operation/GetItems
+    pub async fn series_by_id(&self, series_id: &str) -> anyhow::Result<Item> {
+        let url = self.base_url.join("Items")?;
+        let response = self
+            .client
+            .get(url)
+            .query(&[("ids", series_id), ("fields", "ProviderIds")])
+            .send()
+            .await?
+            .handle_error()
+            .await?
+            .json::<ItemsResponse>()
+            .await?;
+
+        response
+            .items
+            .into_iter()
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("Series with ID {} not found", series_id))
+    }
 }
 
 fn auth_headers(api_key: &str) -> Result<HeaderMap, anyhow::Error> {

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -8,7 +8,7 @@ use log::trace;
 pub use radarr_client::{Movie, RadarrClient};
 #[cfg(test)]
 pub use sonarr_client::{Season, SeasonStatistics, SeriesStatistics};
-pub use sonarr_client::{SeriesInfo, SonarrClient};
+pub use sonarr_client::{EpisodeInfo, SeriesInfo, SonarrClient};
 pub use torrent_clients::{DelugeClient, QbittorrentClient, TorrentClient, TorrentClientKind};
 
 use anyhow::bail;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use cleaners::{MoviesCleaner, SeriesCleaner};
+use cleaners::{EpisodesCleaner, MoviesCleaner};
 use cli::Cli;
 use http::JellyfinClient;
 use services::DownloadService;
@@ -27,7 +27,7 @@ async fn main() -> anyhow::Result<()> {
         download_client.clone(),
     )?;
 
-    let series_cleaner = SeriesCleaner::new(
+    let episodes_cleaner = EpisodesCleaner::new(
         config.sonarr,
         jellyfin_client.clone(),
         download_client.clone(),
@@ -36,7 +36,7 @@ async fn main() -> anyhow::Result<()> {
     movies_cleaner
         .cleanup(&config.username, args.force_delete)
         .await?;
-    series_cleaner
+    episodes_cleaner
         .cleanup(&config.username, args.force_delete)
         .await?;
 


### PR DESCRIPTION
## Summary

This PR implements episode-level deletion for TV show cleanup, replacing the previous series-level deletion approach. Instead of deleting entire series when all episodes are watched, this feature deletes individual episodes while preserving the series and unwatched episodes.

This provides fine-grained control over disk space usage and allows users to keep series metadata even after watching all current episodes.

## Key Features

- **Episode-level deletion**: Delete only watched episodes, preserve series
- **Unmonitor-first pattern**: Prevents Sonarr from re-downloading deleted episodes
- **Retention period filtering**: Respects user-configured retention periods
- **Tag protection**: Skips series with forbidden tags
- **Comprehensive validation**: Warns on missing TVDB IDs, episode numbers, files
- **Per-episode error handling**: Continues processing despite individual failures
- **Detailed logging**: Clear visibility into deletion decisions at all steps

## Implementation Details

### Files Changed

- **NEW**: `src/cleaners/episodes.rs` (412 lines) - EpisodesCleaner implementation
- **MODIFIED**: `src/http/jellyfin_client.rs` - Added episode fields (season, episode, series_id)
- **MODIFIED**: `src/http/sonarr_client.rs` - Added episode API methods and EpisodeInfo struct
- **MODIFIED**: `src/main.rs` - Use EpisodesCleaner instead of SeriesCleaner
- **MODIFIED**: `src/cleaners/mod.rs` - Export EpisodesCleaner
- **MODIFIED**: `src/http/mod.rs` - Export EpisodeInfo

### Critical Improvements

1. **Jellyfin Field Requests**: Explicitly request ProviderIds, SeriesId, SeriesName to ensure all required data is available for episode matching

2. **Unmonitor-First Pattern**: Episodes are unmonitored BEFORE file deletion to prevent Sonarr from seeing them as "missing" and re-downloading them. This prevents wasted bandwidth.

3. **Per-Episode Error Handling**: Each episode deletion is wrapped in error handling. If one episode fails, others continue processing. Success/failure counts are logged with an aggregate error returned only at completion.

4. **Field Validation & Logging**: Missing TVDB IDs, episode numbers, or files on disk are validated and logged appropriately with actionable messages.

### New API Methods

```rust
// Get all episodes for a series
episodes_by_series(series_id: u64) -> Vec<EpisodeInfo>

// Delete episode file from disk
delete_episode_file(file_id: u64) -> Result

// Get episode file info by series
episode_files_by_series(series_id: u64) -> Vec<EpisodeFileInfo>

// Unmonitor episode (prevent re-download)
unmonitor_episode(episode_id: u64) -> Result
```

### Episode Matching Strategy

Episodes are matched by season/episode number (from Jellyfin) instead of episode IDs because Jellyfin and Sonarr use different ID systems.

**Known Limitations**:
- Special episodes (Season 0) may number differently between systems
- Absolute numbering (anime) may not map correctly to season/episode

## Testing

- ✅ Builds successfully with no errors
- ✅ Docker image builds and runs
- ✅ Manual integration testing completed
- ✅ Executes episode-level deletion code path correctly
- ✅ Proper logging output verified

## Backward Compatibility

SeriesCleaner remains in the codebase (`src/cleaners/series.rs`) but is no longer used by default. Users can opt to keep SeriesCleaner if they prefer series-level deletion by manually editing `src/main.rs`.

For most use cases, EpisodesCleaner provides superior control and should be used as the default for TV show cleanup.

## Code Quality

- Comprehensive module-level documentation (46 lines)
- Per-episode error tracking and logging
- Field validation at all decision points
- Follows existing code patterns and conventions
- Proper error handling with anyhow::Result

## Related Issues

This change addresses the limitation where sanitarr could only delete entire TV series. With episode-level deletion, users gain granular control over which watched episodes to remove while keeping series metadata and unwatched episodes intact.